### PR TITLE
iOSD SDK 6.1.0

### DIFF
--- a/_data/releasenotesios.yaml
+++ b/_data/releasenotesios.yaml
@@ -21,6 +21,7 @@ Limited:
 #Regular Release
 Regular: 
   versions: [
+    { version: "6.1.0" },
     { version: "6.0.1" },
     { version: "6.0.0" },
     { version: "5.2.0" },

--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/AdvancedFeatures/welcome-message-with-quick-replies.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/AdvancedFeatures/welcome-message-with-quick-replies.md
@@ -49,6 +49,9 @@ let welcomeMessageParam = LPWelcomeMessage(message: "Hello Mr.Bond")
 LPMessaging.instance.showConversation(conversationViewParams,  authenticationParams: authenticationParams)
 ```
 
+{: .notice}
+Currently this feature is not fully compatible with the [Control History APIs](mobile-app-messaging-sdk-for-ios-sdk-apis-control-history-apis.html).
+
 ### Limitations
 - You can configure up to 24 quick reply options, but you have a 25 character limit per quick reply option.  
 
@@ -62,10 +65,10 @@ LPMessaging.instance.showConversation(conversationViewParams,  authenticationPar
 
    ```
    "metadata": [
-   {
-   "type": "ExternalId",
-   "id": "Yes-1234"
-   }
+        {
+            "type": "ExternalId",
+            "id": "Yes-1234"
+        }
    ]
    ```
 

--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/QuickStarts/quick-start-6-0-and-up-xcframework-support.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/QuickStarts/quick-start-6-0-and-up-xcframework-support.md
@@ -187,7 +187,7 @@ class DocumentationViewController: UIViewController {
         
         let conversationQuery = LPMessaging.instance.getConversationBrandQuery(accountID)
         
-        let controlParam = LPConversationHistoryControlParam(historyConversationsStateToDisplay: .none,
+        let controlParam = LPConversationHistoryControlParam(historyConversationsStateToDisplay: .all,
         historyConversationsMaxDays: -1,
         historyMaxDaysType: .startConversationDate)
         
@@ -329,7 +329,7 @@ class DocumentationViewController: UIViewController {
     Here your view controller will call our showConversation method provided by the LPMessagingSDK instance.  This will push on a new navigation stack containing the Conversation View Controller.  You would not need to authenticate as the LPMessagingSDK instance already has knowledge about your account from the monitoring information provided above. The Conversational Cloud console site attached to this account only has a basic set of features available to demonstrate the Conversational Commerce experience.
     */
     let conversationQuery = LPMessaging.instance.getConversationBrandQuery(accountID)
-    let historyControlParam = LPConversationHistoryControlParam(historyConversationsStateToDisplay: .none, historyConversationsMaxDays: -1, historyMaxDaysType: .startConversationDate)
+    let historyControlParam = LPConversationHistoryControlParam(historyConversationsStateToDisplay: .all, historyConversationsMaxDays: -1, historyMaxDaysType: .startConversationDate)
     let welcomeMessage = LPWelcomeMessage(message: "Hello, how may I help you?", frequency: .FirstTimeConversation)
     let conversationViewParams = LPConversationViewParams(conversationQuery: conversationQuery,
     containerViewController: nil, isViewOnly: false, conversationHistoryControlParam: historyControlParam, welcomeMessage: welcomeMessage)

--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/ReleaseNotes/Regular/6.1.0.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/ReleaseNotes/Regular/6.1.0.md
@@ -1,0 +1,42 @@
+### Version 6.1.0
+#### iOS Messaging SDK
+
+**Release Date**: November 3, 2020
+
+##### Environmental Requirements
+The iOS Mobile Messaging SDK version 6.1.0 is supported on iOS versions 12 through 14. 
+
+{: .notice} 
+XCFramework is supported on CocoaPad versions 1.9.0 and greater.
+
+#### Enhancements
+* Change LPLogger default level to .DEBUG from .TRACE
+
+#### Bugs fixed
+* Fixed issue where In-App Notification is shown behind ConversationViewController if presented modally,
+* Fixed issue when Welcome Message is not presented after PCS expires,
+* Fixed issue when Welcome Message is not presented when force closing CSAT,
+* Fixed issue where connection banner is not presented on correct scenario:
+    - “Failed to connect to the server” banner is presented before “Offline...  Please check your connection” banner after losing internet connection.
+* Fixed issue where Quick Reply messages are out of order when scrolling,
+* Fixed issue where Messages are displayed out of order when using continuity between Web and In-App,
+* Fixed issue when Unread message count notification will be shown above Welcome Message.
+* Fixed issue where SDK will crash while:
+    - Updating dialog participants for a new conversation,
+    - Downloading images from remote URL,
+    - Scrolling the conversation screen,
+    - Trying to clear Conversation from DB,
+    - calling LPLoggingHistory.removeFromHistory(),
+    - calling LPMessagingSDK.clearLocalDatabase(),
+    - calling ConversationViewController.scrollTableViewTo(),
+    - calling lpFetchedControllerDidChangeContent()
+* Fixed issue where SDK will crash with error _Invalid_Number_Of_Rows_In_Section,
+* Fixed issue where a Welcome Message with Quick Replies will cause a crash while presenting the Conversation Screen.
+
+#### Known Issues 
+* Issue with user link message can’t be double tap to open link when VoiceOver is enable,
+* Message timestamp for Images/Files/Audio gets be cutoff when using Large Fonts on Accessibility Settings,
+* VoiceOver not reading agent name while focusing on structure content container,
+* Unread message count divider not showing on conversation screen when Agent sends only one message.
+
+

--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/SDKAPIs/control-history-apis.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/SDKAPIs/control-history-apis.md
@@ -38,6 +38,9 @@ The APIs lets brands:
 
 * Every message that arrives from the agent or sent by the consumer removes the filter and conversations present as if no filter was applied.
 
+{: .notice}
+Currently this feature is not fully compatible with the [Welcome Message with Quick Replies](mobile-app-messaging-sdk-for-ios-advanced-features-welcome-message-with-quick-replies.html).
+
 ### Parameters
 
 LPConversationViewParams includes LPConversationHistoryControlParam:

--- a/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/SDKAttributes/sdk-5-0-and-above.md
+++ b/pages/Documents/MessagingChannels/MobileAppMessagingSDKforiOS/SDKAttributes/sdk-5-0-and-above.md
@@ -2032,7 +2032,11 @@ If setting nil - default avatar image will be used with `remoteUserAvatarBackgro
    - **Type:** UIImage?
    - **Default value:** nil 
 
+#### brandAvatarImageContentMode
+Sets content mode for the brand avatar image
 
+- **Type:** UIView.ContentMode
+- **Default value:** .scaleAspectFit
 
 #### csatAgentAvatarBackgroundColor 
 Background color of agent's default avatar in CSAT. 


### PR DESCRIPTION
- releasenotesios.yaml:
   - Adding release number 6.1.0
- quick-start-6-0-and-up-xcframework-support.md:
   - Fixed reference to deleted object .none to new reference .all on Enum LPConversationsHistoryStateToDisplay
- sdk-5-0-and-above.md:
   - Adding branding description for brandAvatarImageContentMode
- Adding note for usage of HistoryControlAPI & WM:
   - welcome-message-with-quick-replies.md,
   - control-history-apis.md,
- 6.1.0.md:
   - Adding release notes.